### PR TITLE
Draft to use trust information to filter results - only lunr indexer

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 const HOST = process.env.HOST || "0.0.0.0";
 const PORT = parseInt(process.env.PORT) || 3000;
 const METADATA = process.env.METADATA || "/etc/metadata.json";
+const TRUSTINFO = process.env.TRUSTINFO || "/etc/trustinfo.json";
 const BASE_URL = process.env.BASE_URL || "";
 const RELOAD_ON_CHANGE = JSON.parse(process.env.RELOAD_ON_CHANGE || "true") || true;
 
@@ -43,10 +44,12 @@ cluster.on('exit', function (worker) {
 if (cluster.isMaster) {
     const cpuCount = os.cpus().length;
     for (let j = 0; j < cpuCount; j++) {
+        console.log(`Forking ${j}`);
         cluster.fork();
     }
 } else {
-    load_metadata(METADATA).then((md) => {
-        app.locals.md = md
+    load_metadata(METADATA, TRUSTINFO).then((md) => {
+        app.locals.md = md;
+        console.log('Loaded metadata');
     }).then(() => runServer(app));
 }

--- a/metadata.js
+++ b/metadata.js
@@ -61,7 +61,6 @@ class Metadata {
                         "id": e.id,
                         "entityID": e.entityID,
                         "title": [e.title.toLocaleLowerCase(locales)],
-                        "registrationAuthority": e.registrationAuthority,
                     };
                     if (e.keywords) {
                         doc.keywords = e.keywords.toLocaleLowerCase(locales).split(",").map(e=>e.trim())
@@ -80,6 +79,15 @@ class Metadata {
                     }
                     doc.title = [...new Set(doc.title)].sort()
                     doc.scopes = [...new Set(doc.scopes)].sort()
+                    if (e.registrationAuthority) {
+                        doc.registrationAuthority = e.registrationAuthority;
+                    }
+                    if (e.entity_categories) {
+                        doc.entity_categories = e.entity_categories;
+                    }
+                    if (e.md_sources) {
+                        doc.md_sources = e.md_sources;
+                    }
                     //console.log(doc)
                     this.idx.add(doc);
                 }

--- a/metadata.js
+++ b/metadata.js
@@ -203,7 +203,7 @@ class Metadata {
                 const preResults = indexResults.map(m => (m.ref));
                 console.log(`Preresults ${preResults}`);
                 Object.values(self.mdDb).forEach(function(m) {
-                    if (m.trusted !== undefined && preResults.includes(_sha1_id(m.entityID))) {
+                    if (m.trusted === undefined && preResults.includes(_sha1_id(m.entityID))) {
                         // console.log(`found ${m.entityID}`);
                         m.trusted = trustProfile.display_name;
                     }

--- a/metadata.js
+++ b/metadata.js
@@ -82,11 +82,17 @@ class Metadata {
                     if (e.registrationAuthority) {
                         doc.registrationAuthority = e.registrationAuthority;
                     }
-                    if (e.entity_categories) {
-                        doc.entity_categories = e.entity_categories;
+                    if (e.entity_category) {
+                        doc.entity_category = e.entity_category;
                     }
-                    if (e.md_sources) {
-                        doc.md_sources = e.md_sources;
+                    if (e.entity_category_support) {
+                        doc.entity_category_support = e.entity_category_support;
+                    }
+                    if (e.assurance_certification) {
+                        doc.assurance_certification = e.assurance_certification;
+                    }
+                    if (e.md_source) {
+                        doc.md_source = e.md_source;
                     }
                     //console.log(doc)
                     this.idx.add(doc);

--- a/metadata.js
+++ b/metadata.js
@@ -203,7 +203,7 @@ class Metadata {
                 const preResults = indexResults.map(m => (m.ref));
                 console.log(`Preresults ${preResults}`);
                 Object.values(self.mdDb).forEach(function(m) {
-                    if (preResults.includes(_sha1_id(m.entityID))) {
+                    if (m.trusted !== undefined && preResults.includes(_sha1_id(m.entityID))) {
                         // console.log(`found ${m.entityID}`);
                         m.trusted = trustProfile.display_name;
                     }

--- a/metadata.js
+++ b/metadata.js
@@ -120,12 +120,9 @@ class Metadata {
                 const extraMetadata = self.tiDb[entityID]['extra_md'];
 
                 trustProfile.entity.forEach((e) => {
-                    let isExtra = false;
                     if (extraMetadata && e.entity_id in extraMetadata) {
-                        isExtra = true;
                         extraIdPs.push(extraMetadata[e.entity_id]);
-                    }
-                    if (!isExtra) {
+                    } else {
                         // console.log(`Adding entity term to query ${e.entity_id}, ${e.include}`);
                         self.idx.addTermToQuery(query, e.entity_id, ['entityID'], e.include);
                         emptyQuery = false;

--- a/search-index.js
+++ b/search-index.js
@@ -19,8 +19,10 @@ export class lunrIndexer {
         this.builder.field('keywords');
         this.builder.field('entityID');
         this.builder.field('registrationAuthority');
-        this.builder.field('entity_categories');
-        this.builder.field('md_sources');
+        this.builder.field('entity_category');
+        this.builder.field('md_source');
+        this.builder.field('entity_category_support');
+        this.builder.field('assurance_certification');
 
         lunr.tokenizer.separator = /\s+/;
     };

--- a/search-index.js
+++ b/search-index.js
@@ -17,6 +17,8 @@ export class lunrIndexer {
         this.builder.field('tags');
         this.builder.field('scopes');
         this.builder.field('keywords');
+        this.builder.field('entityID');
+        this.builder.field('registrationAuthority');
 
         lunr.tokenizer.separator = /\s+/;
     };
@@ -30,7 +32,28 @@ export class lunrIndexer {
     };
 
     search(q) {
-        return this.idx.search(q);
+        const queryBuilder = (query) => {
+            q.forEach((clause) => {
+                query.clause(clause);
+            });
+        };
+        return this.idx.query(queryBuilder);
+    }
+
+    newQuery() {
+        return [];
+    }
+
+    addTermToQuery(query, term, fields, include) {
+        let presence = lunr.Query.presence.PROHIBITED;
+        if (include) {
+            presence = lunr.Query.presence.REQUIRED;
+        }
+        query.push({
+            term: term,
+            fields: fields,
+            presence: presence,
+        });
     }
 };
 

--- a/search-index.js
+++ b/search-index.js
@@ -19,6 +19,8 @@ export class lunrIndexer {
         this.builder.field('keywords');
         this.builder.field('entityID');
         this.builder.field('registrationAuthority');
+        this.builder.field('entity_categories');
+        this.builder.field('md_sources');
 
         lunr.tokenizer.separator = /\s+/;
     };

--- a/test/disco.json
+++ b/test/disco.json
@@ -14,8 +14,11 @@
     "entity_id": "https://login.idp.eduid.se/idp.xml",
     "entityID": "https://login.idp.eduid.se/idp.xml",
     "registrationAuthority": "http://www.swamid.se/",
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "assurance_certification": [
+      "https://refeds.org/sirtfi"
     ],
     "type": "idp",
     "hidden": "false",
@@ -45,7 +48,7 @@
     "entity_id": "https://idp.u-picardie.fr/idp/shibboleth",
     "entityID": "https://idp.u-picardie.fr/idp/shibboleth",
     "registrationAuthority": "https://federation.renater.fr/",
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
     ],
     "type": "idp",
@@ -74,7 +77,7 @@
     "entity_id": "https://cafe.usf.edu.br/idp/shibboleth",
     "entityID": "https://cafe.usf.edu.br/idp/shibboleth",
     "registrationAuthority": "http://cafe.rnp.br",
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
     ],
     "type": "idp",
@@ -98,7 +101,7 @@
     "entity_id": "https://kimlik.29mayis.edu.tr/simplesaml/saml2/idp/metadata.php",
     "entityID": "https://kimlik.29mayis.edu.tr/simplesaml/saml2/idp/metadata.php",
     "registrationAuthority": "https://yetkim.org.tr/",
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
     ],
     "type": "idp",
@@ -129,8 +132,11 @@
     "entity_id": "https://a-star.singaren.net.sg/simplesaml/saml2/idp/metadata.php",
     "entityID": "https://a-star.singaren.net.sg/simplesaml/saml2/idp/metadata.php",
     "registrationAuthority": "https://www.singaren.net.sg",
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "entity_category_support": [
+      "http://www.geant.net/uri/dataprotection-code-of-conduct/v1"
     ],
     "type": "idp",
     "hidden": "false",
@@ -149,10 +155,10 @@
     "entity_id": "https://my.atsu.edu/swPublicSSO/SAML/incommon",
     "entityID": "https://my.atsu.edu/swPublicSSO/SAML/incommon",
     "registrationAuthority": "https://incommon.org",
-    "entity_categories": [
+    "entity_category": [
       "http://id.incommon.org/category/registered-by-incommon"
     ],
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
     ],
     "type": "idp",
@@ -180,11 +186,11 @@
     "entity_id": "https://vho.aaf.edu.au/idp/shibboleth",
     "entityID": "https://vho.aaf.edu.au/idp/shibboleth",
     "registrationAuthority": "https://aaf.edu.au",
-    "entity_categories": [
+    "entity_category": [
       "http://refeds.org/category/research-and-scholarship",
       "http://www.geant.net/uri/dataprotection-code-of-conduct/v1"
     ],
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
     ],
     "type": "idp",
@@ -207,8 +213,11 @@
     "entity_id": "https://idp.sdju.edu.cn/idp/shibboleth",
     "entityID": "https://idp.sdju.edu.cn/idp/shibboleth",
     "registrationAuthority": "https://www.carsi.edu.cn",
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "assurance_certification": [
+      "https://refeds.org/sirtfi"
     ],
     "type": "idp",
     "hidden": "false",
@@ -234,7 +243,7 @@
     "entity_id": "https://aai-login.swissuniversities.ch/idp/shibboleth",
     "entityID": "https://aai-login.swissuniversities.ch/idp/shibboleth",
     "registrationAuthority": "http://rr.aai.switch.ch/",
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
     ],
     "type": "idp",
@@ -261,7 +270,7 @@
     "entity_id": "http://adfs.ftik.edu.om/adfs/services/trust",
     "entityID": "http://adfs.ftik.edu.om/adfs/services/trust",
     "registrationAuthority": "http://www.omren.om",
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
     ],
     "type": "idp",
@@ -291,7 +300,7 @@
     "entity_id": "https://idp.antagning.se/aws-idp",
     "entityID": "https://idp.antagning.se/aws-idp",
     "registrationAuthority": "http://www.swamid.se/",
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
     ],
     "type": "idp",
@@ -320,11 +329,17 @@
     "entity_id": "https://logindev.rowan.edu",
     "entityID": "https://logindev.rowan.edu",
     "registrationAuthority": "https://incommon.org",
-    "entity_categories": [
+    "entity_category": [
       "http://id.incommon.org/category/registered-by-incommon"
     ],
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "assurance_certification": [
+      "https://refeds.org/sirtfi"
+    ],
+    "entity_category_support": [
+      "http://www.geant.net/uri/dataprotection-code-of-conduct/v1"
     ],
     "type": "idp",
     "hidden": "false",
@@ -351,10 +366,10 @@
     "entity_id": "https://fed-uat.it.northwestern.edu/idp/shibboleth",
     "entityID": "https://fed-uat.it.northwestern.edu/idp/shibboleth",
     "registrationAuthority": "https://incommon.org",
-    "entity_categories": [
+    "entity_category": [
       "http://id.incommon.org/category/registered-by-incommon"
     ],
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
     ],
     "type": "idp",
@@ -382,11 +397,11 @@
     "entity_id": "https://passport-dev.pitt.edu/idp/shibboleth",
     "entityID": "https://passport-dev.pitt.edu/idp/shibboleth",
     "registrationAuthority": "https://incommon.org",
-    "entity_categories": [
+    "entity_category": [
       "http://refeds.org/category/hide-from-discovery",
       "http://id.incommon.org/category/registered-by-incommon"
     ],
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
     ],
     "type": "idp",
@@ -414,11 +429,11 @@
     "entity_id": "urn:mace:incommon:iu.edu",
     "entityID": "urn:mace:incommon:iu.edu",
     "registrationAuthority": "https://incommon.org",
-    "entity_categories": [
+    "entity_category": [
       "http://refeds.org/category/hide-from-discovery",
       "http://id.incommon.org/category/registered-by-incommon"
     ],
-    "md_sources": [
+    "md_source": [
       "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
     ],
     "type": "idp",

--- a/test/disco.json
+++ b/test/disco.json
@@ -1,0 +1,436 @@
+[
+  {
+    "title": "eduID Sweden",
+    "descr": "eduID gives you a common login for your education",
+    "title_langs": {
+      "en": "eduID Sweden",
+      "sv": "eduID Sverige"
+    },
+    "descr_langs": {
+      "en": "eduID gives you a common login for your education",
+      "sv": "eduID är en gemensam inloggning för din utbildning"
+    },
+    "auth": "saml",
+    "entity_id": "https://login.idp.eduid.se/idp.xml",
+    "entityID": "https://login.idp.eduid.se/idp.xml",
+    "registrationAuthority": "http://www.swamid.se/",
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "eduid.se",
+    "domain": "eduid.se",
+    "name_tag": "EDUID",
+    "entity_icon_url": {
+      "url": "https://eduid.se/static/img/ds-eduID-logo-black350x120px.png",
+      "width": "350",
+      "height": "120"
+    },
+    "keywords": "eduID+studentIdP",
+    "privacy_statement_url": "https://eduid.se/en/faq.html"
+  },
+  {
+    "title": "Université de Picardie Jules Verne",
+    "descr": "Université de Picardie Jules Verne v3",
+    "title_langs": {
+      "en": "Université de Picardie Jules Verne",
+      "fr": "Université de Picardie Jules Verne"
+    },
+    "descr_langs": {
+      "en": "Université de Picardie Jules Verne v3",
+      "fr": "Université de Picardie Jules Verne v3"
+    },
+    "auth": "saml",
+    "entity_id": "https://idp.u-picardie.fr/idp/shibboleth",
+    "entityID": "https://idp.u-picardie.fr/idp/shibboleth",
+    "registrationAuthority": "https://federation.renater.fr/",
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "u-picardie.fr",
+    "domain": "u-picardie.fr",
+    "name_tag": "U-PICARDIE",
+    "entity_icon_url": {
+      "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAK6wAACusBgosNWgAAABx0RVh0U29mdHdhcmUAQWRvYmUgRmlyZXdvcmtzIENTNui8sowAAAAWdEVYdENyZWF0aW9uIFRpbWUAMTIvMTkvMTOFkvAWAAAB+0lEQVQ4jZ2RvWsTARjGf3e5XBuT1iSEJK0oSVoxaKURaR2kUgSHbp2KbgVx0VVwEay7g8U/QHERN0EH0aXi5Ac0ShsLLdqGxKT5MLlcLrlc7nIOldBI8KPP9L7Py/t7X3iE18ms7R50kqs0GPG50HQLySHglEQyJY0Rn4uKZhDyupB/ebLTgdWxKSo60mauxuljPjLlBrVGm0bLZFB2cOFUmOXnKS5NjrKRVYgfOYxTEgFQm20iQQ/5ahPhzpNVWxIFzI4NgCCAvVcCIAoCogimtc/cJ+nZuzTTxwN83qlwNODG55HZyql43TJq0wAEzsT8bOVqvEp+R9PNXkBZbfF+s0RVMyjVdNRmm8DwAErDoNOxqesmZbWF3rawLJtI0APAdqG+B8iUNTJlrYdaUPS+7yaifpLffvR44uxEuEv9kyJBT/dqD2BlLd8zWLqc6AvYLtSpaka3FwRwyQ4cxOeXvG6Z63NxYqEhxsJDzJwM8WY9301j8eI4N+biACycj5IuaTy4do6zYwEkAMPsUNUMdooaL1ezTI0Heq6vrOUpKjobWYW3qV1mJ8IoWptbjz8iMP+wf8B/0b3FKb5kqoiJqB+vW/5vwM1HH7gyE0P6PZZ/ldMhsp6uIh5oG7i9MMnyi9TBAIcGJE6MDvN1Vz0Y4P7Vae4+/QTAT/Yrzd5r4IOsAAAAAElFTkSuQmCC",
+      "width": "16",
+      "height": "16"
+    }
+  },
+  {
+    "title": "USF - Universidade Sao Francisco",
+    "descr": "USF - Universidade Sao Francisco",
+    "title_langs": {
+      "en": "USF - Universidade Sao Francisco",
+      "pt-br": "USF - Universidade Sao Francisco"
+    },
+    "descr_langs": {
+      "en": "USF - Universidade Sao Francisco",
+      "pt-br": "USF - Universidade Sao Francisco"
+    },
+    "auth": "saml",
+    "entity_id": "https://cafe.usf.edu.br/idp/shibboleth",
+    "entityID": "https://cafe.usf.edu.br/idp/shibboleth",
+    "registrationAuthority": "http://cafe.rnp.br",
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "usf.edu.br",
+    "domain": "usf.edu.br",
+    "name_tag": "USF"
+  },
+  {
+    "title": "29 Mayis University",
+    "descr": "29 Mayis University Identity Provider",
+    "title_langs": {
+      "tr": "29 Mayıs Üniversitesi",
+      "en": "29 Mayis University"
+    },
+    "descr_langs": {
+      "en": "29 Mayis University Identity Provider",
+      "tr": "29 Mayıs Üniversitesi Kimlik Doğrulama Servisi"
+    },
+    "auth": "saml",
+    "entity_id": "https://kimlik.29mayis.edu.tr/simplesaml/saml2/idp/metadata.php",
+    "entityID": "https://kimlik.29mayis.edu.tr/simplesaml/saml2/idp/metadata.php",
+    "registrationAuthority": "https://yetkim.org.tr/",
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "29mayis.edu.tr",
+    "domain": "29mayis.edu.tr",
+    "name_tag": "29MAYIS",
+    "entity_icon_url": {
+      "url": "https://kimlik.29mayis.edu.tr/simplesaml/assets/icons/logo.png",
+      "width": "97",
+      "height": "97"
+    },
+    "geo": {
+      "lat": "1.031254",
+      "long": "29.099033"
+    }
+  },
+  {
+    "title": "A*STAR - Agency for Science, Technology and Research",
+    "descr": "Login portal for A*STAR users",
+    "title_langs": {
+      "en": "A*STAR - Agency for Science, Technology and Research"
+    },
+    "descr_langs": {
+      "en": "Login portal for A*STAR users"
+    },
+    "auth": "saml",
+    "entity_id": "https://a-star.singaren.net.sg/simplesaml/saml2/idp/metadata.php",
+    "entityID": "https://a-star.singaren.net.sg/simplesaml/saml2/idp/metadata.php",
+    "registrationAuthority": "https://www.singaren.net.sg",
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "a-star.singaren.net.sg,a-star.edu.sg"
+  },
+  {
+    "title": "A. T. Still University",
+    "descr": "A.T. Still University of Health Sciences serves as a learning-centered university dedicated to preparing highly competent professionals through innovative academic programs with a commitment to continue its osteopathic heritage and focus on whole person healthcare, scholarship, community health, interprofessional education, diversity, and underserved populations",
+    "title_langs": {
+      "en": "A. T. Still University"
+    },
+    "descr_langs": {
+      "en": "A.T. Still University of Health Sciences serves as a learning-centered university dedicated to preparing highly competent professionals through innovative academic programs with a commitment to continue its osteopathic heritage and focus on whole person healthcare, scholarship, community health, interprofessional education, diversity, and underserved populations"
+    },
+    "auth": "saml",
+    "entity_id": "https://my.atsu.edu/swPublicSSO/SAML/incommon",
+    "entityID": "https://my.atsu.edu/swPublicSSO/SAML/incommon",
+    "registrationAuthority": "https://incommon.org",
+    "entity_categories": [
+      "http://id.incommon.org/category/registered-by-incommon"
+    ],
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "atsu.edu",
+    "domain": "atsu.edu",
+    "name_tag": "ATSU",
+    "entity_icon_url": {
+      "url": "https://www.atsu.edu/themes/atsu/images/logo_atsu.png",
+      "width": "375",
+      "height": "42"
+    },
+    "privacy_statement_url": "https://www.atsu.edu/privacy-policy"
+  },
+  {
+    "title": "AAF Virtual Home",
+    "descr": "Australian Access Federation Virtual Home Organization",
+    "title_langs": {
+      "en": "AAF Virtual Home"
+    },
+    "descr_langs": {
+      "en": "Australian Access Federation Virtual Home Organization"
+    },
+    "auth": "saml",
+    "entity_id": "https://vho.aaf.edu.au/idp/shibboleth",
+    "entityID": "https://vho.aaf.edu.au/idp/shibboleth",
+    "registrationAuthority": "https://aaf.edu.au",
+    "entity_categories": [
+      "http://refeds.org/category/research-and-scholarship",
+      "http://www.geant.net/uri/dataprotection-code-of-conduct/v1"
+    ],
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "vho.aaf.edu.au",
+    "domain": "vho.aaf.edu.au",
+    "name_tag": "VHO"
+  },
+  {
+    "title": "shanghai dianji university",
+    "descr": "sdju.edu.cn",
+    "title_langs": {
+      "en": "shanghai dianji university",
+      "zh": "上海电机学院(shanghai dianji university)"
+    },
+    "descr_langs": {
+      "en": "sdju.edu.cn"
+    },
+    "auth": "saml",
+    "entity_id": "https://idp.sdju.edu.cn/idp/shibboleth",
+    "entityID": "https://idp.sdju.edu.cn/idp/shibboleth",
+    "registrationAuthority": "https://www.carsi.edu.cn",
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "sdju.edu.cn",
+    "domain": "sdju.edu.cn",
+    "name_tag": "SDJU",
+    "entity_icon_url": {
+      "url": "https://mgmt.carsi.edu.cn/member_files/sdju.edu.cn/sdju.edu.cn-logo.png",
+      "width": "80",
+      "height": "80"
+    }
+  },
+  {
+    "title": "swissuniversities",
+    "descr": "Gemeinsames hochschulpolitisches Organ",
+    "title_langs": {
+      "en": "swissuniversities"
+    },
+    "descr_langs": {
+      "en": "Gemeinsames hochschulpolitisches Organ"
+    },
+    "auth": "saml",
+    "entity_id": "https://aai-login.swissuniversities.ch/idp/shibboleth",
+    "entityID": "https://aai-login.swissuniversities.ch/idp/shibboleth",
+    "registrationAuthority": "http://rr.aai.switch.ch/",
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "swissuniversities.ch",
+    "domain": "swissuniversities.ch",
+    "name_tag": "SWISSUNIVERSITIES",
+    "entity_icon_url": {
+      "url": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2ZXJzaW9uPSIxLjEiIGlkPSJFYmVuZV8xIiB4PSIwcHgiIHk9IjBweCIgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiB2aWV3Qm94PSIwIDAgMTYgMTYiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDE2IDE2OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0UxMUEyNzt9Cjwvc3R5bGU+CjxnPgoJPHBhdGggY2xhc3M9InN0MCIgZD0iTTEzLjcsMTEuMmMwLDIuOS0yLjUsNC4zLTUuNyw0LjNjLTMsMC01LjgtMS44LTUuOC01LjJoMy4yYzAsMS45LDEuMSwyLjUsMi43LDIuNWMxLjMsMCwyLjQtMC41LDIuNC0xLjcgICBjMC0xLjMtMS40LTEuNC00LjQtMi42Yy0yLTAuNy0zLjQtMS40LTMuNC0zLjljMC0yLjcsMi40LTQuMSw1LjQtNC4xYzMsMCw1LjUsMi4xLDUuNSw0LjhoLTMuM0MxMC4zLDQsOS42LDMuMSw4LDMuMSAgIGMtMS4xLDAtMi4xLDAuNi0yLjEsMS41YzAsMS4yLDEuMywxLjQsNCwyLjRDMTEuOSw3LjksMTMuNyw4LjUsMTMuNywxMS4yIi8+CjwvZz4KPC9zdmc+Cg==",
+      "width": "16",
+      "height": "16"
+    }
+  },
+  {
+    "title": "vocational college of marine science (Al khaboura)",
+    "descr": "vocational college of marine science (Al khaboura)",
+    "title_langs": {
+      "en": "vocational college of marine science (Al khaboura)"
+    },
+    "descr_langs": {
+      "en": "vocational college of marine science (Al khaboura)"
+    },
+    "auth": "saml",
+    "entity_id": "http://adfs.ftik.edu.om/adfs/services/trust",
+    "entityID": "http://adfs.ftik.edu.om/adfs/services/trust",
+    "registrationAuthority": "http://www.omren.om",
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "ftik.edu.om",
+    "domain": "ftik.edu.om",
+    "name_tag": "FTIK",
+    "entity_icon_url": {
+      "url": "https://pbs.twimg.com/profile_images/976022822186340353/lC9dUq9J_400x400.jpg",
+      "width": "400",
+      "height": "400"
+    },
+    "privacy_statement_url": "https://www.moheri.gov.om/"
+  },
+  {
+    "title": "www.universityadmissions.se",
+    "descr": "The Identity Provider for students with account in the NyA-system.",
+    "title_langs": {
+      "en": "www.universityadmissions.se",
+      "sv": "www.antagning.se"
+    },
+    "descr_langs": {
+      "en": "The Identity Provider for students with account in the NyA-system.",
+      "sv": "Identity Provider för sökande med konto i NyA-systemet."
+    },
+    "auth": "saml",
+    "entity_id": "https://idp.antagning.se/aws-idp",
+    "entityID": "https://idp.antagning.se/aws-idp",
+    "registrationAuthority": "http://www.swamid.se/",
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "antagning.se",
+    "domain": "antagning.se",
+    "name_tag": "ANTAGNING",
+    "entity_icon_url": {
+      "url": "https://www.universityadmissions.se/images/logo/university-admisssions.png",
+      "width": "205",
+      "height": "52"
+    },
+    "keywords": "antagning.se universityadmissions.se",
+    "privacy_statement_url": "https://universityadmissions.se/en/about-this-website/swamid-service-provider-policy/"
+  },
+  {
+    "title": "z-TestRowanUniversity",
+    "descr": "Test IdP for Rowan University",
+    "title_langs": {
+      "en": "z-TestRowanUniversity"
+    },
+    "descr_langs": {
+      "en": "Test IdP for Rowan University"
+    },
+    "auth": "saml",
+    "entity_id": "https://logindev.rowan.edu",
+    "entityID": "https://logindev.rowan.edu",
+    "registrationAuthority": "https://incommon.org",
+    "entity_categories": [
+      "http://id.incommon.org/category/registered-by-incommon"
+    ],
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "rowan.edu",
+    "domain": "rowan.edu",
+    "name_tag": "ROWAN",
+    "entity_icon_url": {
+      "url": "https://sites.rowan.edu/rowan/_files/_files/images/RowanLogo.png",
+      "width": "393",
+      "height": "58"
+    },
+    "privacy_statement_url": "https://confluence.rowan.edu/display/POLICY/Home"
+  },
+  {
+    "title": "zTest - Northwestern University",
+    "descr": "Northwestern University Shibboleth IdP UAT environment",
+    "title_langs": {
+      "en": "zTest - Northwestern University"
+    },
+    "descr_langs": {
+      "en": "Northwestern University Shibboleth IdP UAT environment"
+    },
+    "auth": "saml",
+    "entity_id": "https://fed-uat.it.northwestern.edu/idp/shibboleth",
+    "entityID": "https://fed-uat.it.northwestern.edu/idp/shibboleth",
+    "registrationAuthority": "https://incommon.org",
+    "entity_categories": [
+      "http://id.incommon.org/category/registered-by-incommon"
+    ],
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "false",
+    "scope": "northwestern.edu",
+    "domain": "northwestern.edu",
+    "name_tag": "NORTHWESTERN",
+    "entity_icon_url": {
+      "url": "https://idsprod.ci.northwestern.edu/public/northwestern-logo.png",
+      "width": "393",
+      "height": "63"
+    },
+    "privacy_statement_url": "https://www.it.northwestern.edu/policies/"
+  },
+  {
+    "title": "zTest - University of Pittsburgh Test IdP",
+    "descr": "Welcome to the test and development IdP Single Sign-On Experience for the University of Pittsburgh. This service is intended for testing and development. Please do not select!",
+    "title_langs": {
+      "en": "zTest - University of Pittsburgh Test IdP"
+    },
+    "descr_langs": {
+      "en": "Welcome to the test and development IdP Single Sign-On Experience for the University of Pittsburgh. This service is intended for testing and development. Please do not select!"
+    },
+    "auth": "saml",
+    "entity_id": "https://passport-dev.pitt.edu/idp/shibboleth",
+    "entityID": "https://passport-dev.pitt.edu/idp/shibboleth",
+    "registrationAuthority": "https://incommon.org",
+    "entity_categories": [
+      "http://refeds.org/category/hide-from-discovery",
+      "http://id.incommon.org/category/registered-by-incommon"
+    ],
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "true",
+    "scope": "pitt.edu",
+    "domain": "pitt.edu",
+    "name_tag": "PITT",
+    "entity_icon_url": {
+      "url": "https://www.pitt.edu/seal/seal-400x400-72rgb.png",
+      "width": "400",
+      "height": "400"
+    },
+    "privacy_statement_url": "https://technology.pitt.edu/research-computing/rc-incommon-shibboleth/privacy.html"
+  },
+  {
+    "title": "zTest Indiana University",
+    "descr": "The Identity Provider for Indiana University.",
+    "title_langs": {
+      "en": "zTest Indiana University"
+    },
+    "descr_langs": {
+      "en": "The Identity Provider for Indiana University."
+    },
+    "auth": "saml",
+    "entity_id": "urn:mace:incommon:iu.edu",
+    "entityID": "urn:mace:incommon:iu.edu",
+    "registrationAuthority": "https://incommon.org",
+    "entity_categories": [
+      "http://refeds.org/category/hide-from-discovery",
+      "http://id.incommon.org/category/registered-by-incommon"
+    ],
+    "md_sources": [
+      "file:///home/eperez/src/git/seamlessaccess/test/edugain-trustinfo-2.0.xml"
+    ],
+    "type": "idp",
+    "hidden": "true",
+    "scope": "iu.edu",
+    "domain": "iu.edu",
+    "name_tag": "IU",
+    "entity_icon_url": {
+      "url": "https://idp.iu.edu/shibboleth-idp/images/iu-logo.png",
+      "width": "350",
+      "height": "64"
+    },
+    "privacy_statement_url": "http://go.iu.edu/authprivacypolicy"
+  }
+]

--- a/test/disco_sp.json
+++ b/test/disco_sp.json
@@ -1,0 +1,525 @@
+[
+  {
+    "entityID": "https://cpauth.icos-cp.eu/saml/cpauth",
+    "extra_md": {
+      "https://login.uleam.cedia.edu.ec/saml2/idp/metadata.php": {
+        "title": "Universidad Laica Eloy Alfaro de Manabí - uleam",
+        "descr": "uleam - Federated access by CEDIA",
+        "title_langs": {
+          "en": "Universidad Laica Eloy Alfaro de Manabí - uleam",
+          "es": "Universidad Laica Eloy Alfaro de Manabí - uleam"
+        },
+        "descr_langs": {
+          "en": "uleam - Federated access by CEDIA",
+          "es": "uleam - Acceso federado ofrecido por CEDIA"
+        },
+        "auth": "saml",
+        "entity_id": "https://login.uleam.cedia.edu.ec/saml2/idp/metadata.php",
+        "entityID": "https://login.uleam.cedia.edu.ec/saml2/idp/metadata.php",
+        "registrationAuthority": "https://minga.cedia.org.ec",
+        "md_sources": [
+          "https://login.uleam.cedia.edu.ec/saml2/idp/metadata.php"
+        ],
+        "type": "idp",
+        "hidden": "false",
+        "scope": "uleam.edu.ec",
+        "domain": "uleam.edu.ec",
+        "name_tag": "ULEAM",
+        "entity_icon_url": {
+          "url": "https://static.cedia.edu.ec/logos/uleam-250x50.png",
+          "width": "200",
+          "height": "160"
+        }
+      }
+    },
+    "profiles": {
+      "customer": {
+        "strict": true,
+        "entity": [
+          {
+            "entity_id": "https://login.uleam.cedia.edu.ec/saml2/idp/metadata.php",
+            "include": true
+          }
+        ],
+        "entities": [
+          {
+            "select": "http://www.swamid.se/",
+            "match": "registrationAuthority",
+            "include": true
+          }
+        ],
+        "display_name": {
+          "en": "Customer Access",
+          "sv": "Kundinloggning"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      },
+      "provider": {
+        "strict": true,
+        "entity": [
+          {
+            "entity_id": "https://cafe.usf.edu.br/idp/shibboleth",
+            "include": true
+          },
+          {
+            "entity_id": "https://idp.u-picardie.fr/idp/shibboleth",
+            "include": true
+          }
+        ],
+        "entities": [],
+        "display_name": {
+          "en": "Provider Access",
+          "sv": "loggning"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/provider"
+        }
+      },
+      "other": {
+        "strict": false,
+        "entity": [
+          {
+            "entity_id": "https://login.idp.eduid.se/idp.xml",
+            "include": true
+          }
+        ],
+        "entities": [],
+        "display_name": {
+          "en": "Other Access",
+          "sv": "Other Access sv"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/other"
+        }
+      },
+      "other2": {
+        "strict": true,
+        "entity": [
+          {
+            "entity_id": "https://login.idp.eduid.se/idp.xml",
+            "include": true
+          }
+        ],
+        "entities": [],
+        "display_name": {
+          "en": "Other2 Access",
+          "sv": "Other2 Access sv"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/other2"
+        }
+      },
+      "another": {
+        "strict": true,
+        "entity": [
+          {
+            "entity_id": "https://login.idp.eduid.se/idp.xml",
+            "include": false
+          }
+        ],
+        "entities": [],
+        "display_name": {
+          "en": "Another Access",
+          "sv": "Another Access"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/another"
+        }
+      },
+      "global1": {
+        "strict": true,
+        "entity": [],
+        "entities": [
+          {
+            "select": "http://www.swamid.se/",
+            "match": "registrationAuthority",
+            "include": true
+          }
+        ],
+        "display_name": {
+          "en": "Global 1 en",
+          "sv": "Global 1 sv"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about1"
+        }
+      }
+    }
+  },
+  {
+    "entityID": "http://fs.liu.se/adfs/services/trust",
+    "profiles": {
+      "other": {
+        "strict": false,
+        "entity": [
+          {
+            "entity_id": "https://kimlik.29mayis.edu.tr/simplesaml/saml2/idp/metadata.php",
+            "include": true
+          }
+        ],
+        "entities": [],
+        "display_name": {
+          "en": "Other Access",
+          "sv": "Other Access sv"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/other"
+        }
+      },
+      "another": {
+        "strict": true,
+        "entity": [
+          {
+            "entity_id": "https://kimlik.29mayis.edu.tr/simplesaml/saml2/idp/metadata.php",
+            "include": false
+          }
+        ],
+        "entities": [],
+        "display_name": {
+          "en": "Another Access",
+          "sv": "Another Access sv"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/another"
+        }
+      },
+      "yetanother": {
+        "strict": false,
+        "entity": [
+          {
+            "entity_id": "https://kimlik.29mayis.edu.tr/simplesaml/saml2/idp/metadata.php",
+            "include": false
+          }
+        ],
+        "entities": [],
+        "display_name": {
+          "en": "yet Another Access",
+          "sv": "yet Another Access sv"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/another"
+        }
+      },
+      "yetanotherone": {
+        "strict": true,
+        "entity": [
+          {
+            "entity_id": "https://kimlik.29mayis.edu.tr/simplesaml/saml2/idp/metadata.php",
+            "include": true
+          }
+        ],
+        "entities": [],
+        "display_name": {
+          "en": "yet Another one Access",
+          "sv": "yet Another one Access sv"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/another"
+        }
+      },
+      "global2": {
+        "strict": true,
+        "entity": [
+          {
+            "entity_id": "https://login.idp.eduid.se/idp.xml",
+            "include": true
+          }
+        ],
+        "entities": [],
+        "display_name": {
+          "en": "Global 2 en",
+          "sv": "Global 2 sv"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about2"
+        }
+      }
+    }
+  },
+  {
+    "entityID": "https://test-edusign.ed-integrations.com/shibboleth",
+    "profiles": {
+      "customer": {
+        "strict": true,
+        "entity": [],
+        "entities": [
+          {
+            "select": "http://www.swamid.se/",
+            "match": "registrationAuthority",
+            "include": true
+          }
+        ],
+        "display_name": {
+          "en": "Customer Access",
+          "sv": "Kundinloggning"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      },
+      "customer2": {
+        "strict": false,
+        "entity": [],
+        "entities": [
+          {
+            "select": "http://www.swamid.se/",
+            "match": "registrationAuthority",
+            "include": true
+          }
+        ],
+        "display_name": {
+          "en": "Customer 2 Access",
+          "sv": "Kundinloggning 2"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      },
+      "customer3": {
+        "strict": true,
+        "entity": [],
+        "entities": [
+          {
+            "select": "http://www.swamid.se/",
+            "match": "registrationAuthority",
+            "include": false
+          }
+        ],
+        "display_name": {
+          "en": "Customer 3 Access",
+          "sv": "Kundinloggning 3"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      },
+      "customer4": {
+        "strict": false,
+        "entity": [],
+        "entities": [
+          {
+            "select": "http://www.swamid.se/",
+            "match": "registrationAuthority",
+            "include": false
+          }
+        ],
+        "display_name": {
+          "en": "Customer 4 Access",
+          "sv": "Kundinloggning 4"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      }
+    }
+  },
+  {
+    "entityID": "https://box-idp.nordu.net/simplesaml/module.php/saml/sp/metadata.php/default-sp",
+    "profiles": {
+      "customer": {
+        "strict": true,
+        "entity": [],
+        "entities": [
+          {
+            "select": "http://refeds.org/category/research-and-scholarship",
+            "match": "entity_categories",
+            "include": true
+          },
+          {
+            "select": "http://www.geant.net/uri/dataprotection-code-of-conduct/v1",
+            "match": "entity_categories",
+            "include": true
+          }
+        ],
+        "display_name": {
+          "en": "Customer Access",
+          "sv": "Kundinloggning"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      },
+      "customer2": {
+        "strict": false,
+        "entity": [],
+        "entities": [
+          {
+            "select": "http://refeds.org/category/research-and-scholarship",
+            "match": "entity_categories",
+            "include": true
+          },
+          {
+            "select": "http://www.geant.net/uri/dataprotection-code-of-conduct/v1",
+            "match": "entity_categories",
+            "include": true
+          }
+        ],
+        "display_name": {
+          "en": "Customer 2 Access",
+          "sv": "Kundinloggning 2"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      },
+      "customer3": {
+        "strict": true,
+        "entity": [],
+        "entities": [
+          {
+            "select": "http://refeds.org/category/research-and-scholarship",
+            "match": "entity_categories",
+            "include": false
+          }
+        ],
+        "display_name": {
+          "en": "Customer 3 Access",
+          "sv": "Kundinloggning 3"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      },
+      "customer4": {
+        "strict": false,
+        "entity": [],
+        "entities": [
+          {
+            "select": "http://refeds.org/category/research-and-scholarship",
+            "match": "entity_categories",
+            "include": false
+          }
+        ],
+        "display_name": {
+          "en": "Customer 4 Access",
+          "sv": "Kundinloggning 4"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      }
+    }
+  },
+  {
+    "entityID": "https://csucoast.infoready4.com/shibboleth",
+    "profiles": {
+      "customer": {
+        "strict": true,
+        "entity": [
+          {
+            "entity_id": "https://login.idp.eduid.se/idp.xml",
+            "include": false
+          }
+        ],
+        "entities": [
+          {
+            "select": "http://www.swamid.se/",
+            "match": "registrationAuthority",
+            "include": true
+          }
+        ],
+        "display_name": {
+          "en": "Customer Access",
+          "sv": "Kundinloggning"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      },
+      "customer2": {
+        "strict": false,
+        "entity": [
+          {
+            "entity_id": "https://login.idp.eduid.se/idp.xml",
+            "include": false
+          }
+        ],
+        "entities": [
+          {
+            "select": "http://www.swamid.se/",
+            "match": "registrationAuthority",
+            "include": true
+          }
+        ],
+        "display_name": {
+          "en": "Customer 2 Access",
+          "sv": "Kundinloggning 2"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      },
+      "customer3": {
+        "strict": true,
+        "entity": [
+          {
+            "entity_id": "https://login.idp.eduid.se/idp.xml",
+            "include": false
+          }
+        ],
+        "entities": [
+          {
+            "select": "http://www.geant.net/uri/dataprotection-code-of-conduct/v1",
+            "match": "entity_categories",
+            "include": true
+          }
+        ],
+        "display_name": {
+          "en": "Customer 3 Access",
+          "sv": "Kundinloggning 3"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      },
+      "customer4": {
+        "strict": false,
+        "entity": [
+          {
+            "entity_id": "https://login.idp.eduid.se/idp.xml",
+            "include": false
+          }
+        ],
+        "entities": [
+          {
+            "select": "http://www.geant.net/uri/dataprotection-code-of-conduct/v1",
+            "match": "entity_categories",
+            "include": true
+          }
+        ],
+        "display_name": {
+          "en": "Customer 4 Access",
+          "sv": "Kundinloggning 4"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      }
+    }
+  }
+]

--- a/test/disco_sp.json
+++ b/test/disco_sp.json
@@ -1,37 +1,6 @@
 [
   {
     "entityID": "https://cpauth.icos-cp.eu/saml/cpauth",
-    "extra_md": {
-      "https://login.uleam.cedia.edu.ec/saml2/idp/metadata.php": {
-        "title": "Universidad Laica Eloy Alfaro de Manabí - uleam",
-        "descr": "uleam - Federated access by CEDIA",
-        "title_langs": {
-          "en": "Universidad Laica Eloy Alfaro de Manabí - uleam",
-          "es": "Universidad Laica Eloy Alfaro de Manabí - uleam"
-        },
-        "descr_langs": {
-          "en": "uleam - Federated access by CEDIA",
-          "es": "uleam - Acceso federado ofrecido por CEDIA"
-        },
-        "auth": "saml",
-        "entity_id": "https://login.uleam.cedia.edu.ec/saml2/idp/metadata.php",
-        "entityID": "https://login.uleam.cedia.edu.ec/saml2/idp/metadata.php",
-        "registrationAuthority": "https://minga.cedia.org.ec",
-        "md_sources": [
-          "https://login.uleam.cedia.edu.ec/saml2/idp/metadata.php"
-        ],
-        "type": "idp",
-        "hidden": "false",
-        "scope": "uleam.edu.ec",
-        "domain": "uleam.edu.ec",
-        "name_tag": "ULEAM",
-        "entity_icon_url": {
-          "url": "https://static.cedia.edu.ec/logos/uleam-250x50.png",
-          "width": "200",
-          "height": "160"
-        }
-      }
-    },
     "profiles": {
       "customer": {
         "strict": true,
@@ -95,24 +64,6 @@
         "fallback_handler": {
           "profile": "href",
           "handler": "https://www.example.org/other"
-        }
-      },
-      "other2": {
-        "strict": true,
-        "entity": [
-          {
-            "entity_id": "https://login.idp.eduid.se/idp.xml",
-            "include": true
-          }
-        ],
-        "entities": [],
-        "display_name": {
-          "en": "Other2 Access",
-          "sv": "Other2 Access sv"
-        },
-        "fallback_handler": {
-          "profile": "href",
-          "handler": "https://www.example.org/other2"
         }
       },
       "another": {
@@ -339,12 +290,12 @@
         "entities": [
           {
             "select": "http://refeds.org/category/research-and-scholarship",
-            "match": "entity_categories",
+            "match": "entity_category",
             "include": true
           },
           {
             "select": "http://www.geant.net/uri/dataprotection-code-of-conduct/v1",
-            "match": "entity_categories",
+            "match": "entity_category",
             "include": true
           }
         ],
@@ -363,12 +314,12 @@
         "entities": [
           {
             "select": "http://refeds.org/category/research-and-scholarship",
-            "match": "entity_categories",
+            "match": "entity_category",
             "include": true
           },
           {
             "select": "http://www.geant.net/uri/dataprotection-code-of-conduct/v1",
-            "match": "entity_categories",
+            "match": "entity_category",
             "include": true
           }
         ],
@@ -387,7 +338,7 @@
         "entities": [
           {
             "select": "http://refeds.org/category/research-and-scholarship",
-            "match": "entity_categories",
+            "match": "entity_category",
             "include": false
           }
         ],
@@ -406,7 +357,7 @@
         "entities": [
           {
             "select": "http://refeds.org/category/research-and-scholarship",
-            "match": "entity_categories",
+            "match": "entity_category",
             "include": false
           }
         ],
@@ -483,7 +434,7 @@
         "entities": [
           {
             "select": "http://www.geant.net/uri/dataprotection-code-of-conduct/v1",
-            "match": "entity_categories",
+            "match": "entity_category",
             "include": true
           }
         ],
@@ -507,13 +458,51 @@
         "entities": [
           {
             "select": "http://www.geant.net/uri/dataprotection-code-of-conduct/v1",
-            "match": "entity_categories",
+            "match": "entity_category",
             "include": true
           }
         ],
         "display_name": {
           "en": "Customer 4 Access",
           "sv": "Kundinloggning 4"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      },
+      "customer5": {
+        "strict": true,
+        "entity": [],
+        "entities": [
+          {
+            "select": "http://www.geant.net/uri/dataprotection-code-of-conduct/v1",
+            "match": "entity_category_support",
+            "include": true
+          }
+        ],
+        "display_name": {
+          "en": "Customer 5 Access",
+          "sv": "Kundinloggning 5"
+        },
+        "fallback_handler": {
+          "profile": "href",
+          "handler": "https://www.example.org/about"
+        }
+      },
+      "customer6": {
+        "strict": true,
+        "entity": [],
+        "entities": [
+          {
+            "select": "https://refeds.org/sirtfi",
+            "match": "assurance_certification",
+            "include": true
+          }
+        ],
+        "display_name": {
+          "en": "Customer 6 Access",
+          "sv": "Kundinloggning 6"
         },
         "fallback_handler": {
           "profile": "href",


### PR DESCRIPTION
* I have only updated the lunr indexer (not the redis one).
* The lunr indexer now has 2 more indexes: registrationAuthority and
   entityID.
* The search for the lunr indexer is more complex now: instead of looking
   for full text presence in all the indexes, it is possible to indicate
   which indexes to look in, and whether to include or exclude the matches.
* In addition to the JSON for the list of IdPs, the app now loads a JSON
   with the trust info, and keeps it in a dict / object keyed by (SP)
   entityID.
* In the search requests, apart from the q param, we can add 2 more
   params, entityID and trustProfile. With these, we get the corresponding
   trust info and use it to filter the list of IdPs.