### PR TITLE
Support searching without diacritics

### DIFF
--- a/metadata.js
+++ b/metadata.js
@@ -7,6 +7,7 @@ import StreamArray from 'stream-json/streamers/StreamArray.js';
 import hex_sha1 from './sha1.js';
 import util from 'util';
 import sw from 'stopword';
+import removeAccents from 'remove-accents';
 
 function _sha1_id(s) {
     return "{sha1}" + hex_sha1(s);
@@ -111,7 +112,10 @@ class Metadata {
         let doc = {
             "id": e.id,
             "entityID": e.entityID,
-            "title": [e.title.toLocaleLowerCase(locales)],
+            "title": [
+                e.title.toLocaleLowerCase(locales), 
+                removeAccents(e.title.toLocaleLowerCase(locales))
+            ],
         };
         doc.keywords = [];
         if (e.keywords) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "fuse.js": "^7.0.0",
         "lunr": "^2.3.9",
         "redis": "^4.7.0",
+        "remove-accents": "^0.5.0",
         "stopword": "^3.1.1",
         "stream": "0.0.3",
         "stream-chain": "^3.2.0",
@@ -5988,6 +5989,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "fuse.js": "^7.0.0",
     "lunr": "^2.3.9",
     "redis": "^4.7.0",
+    "remove-accents": "^0.5.0",
     "stopword": "^3.1.1",
     "stream": "0.0.3",
     "stream-chain": "^3.2.0",

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -76,6 +76,41 @@ describe('', () => {
                 done();
             });
         });
+        it('should return IdP with diacritics when searching without diacritics', (done) => {
+            const q = "universite";
+            chai.request.execute(app)
+                .get(`/entities?q=${q}`)
+                .end((err,res) => {
+                    chai.expect(res.status).to.equal(200);
+                    let data = res.body;
+                    chai.expect(data.length).to.equal(1);
+                    chai.expect(data[0].entityID).to.equal("https://idp.u-picardie.fr/idp/shibboleth");
+                done();
+            });
+        });
+        it('should return IdP with diacritics when searching with matching diacritics', (done) => {
+            const q = "université";
+            chai.request.execute(app)
+                .get(`/entities?q=${q}`)
+                .end((err,res) => {
+                    chai.expect(res.status).to.equal(200);
+                    let data = res.body;
+                    chai.expect(data.length).to.equal(1);
+                    chai.expect(data[0].entityID).to.equal("https://idp.u-picardie.fr/idp/shibboleth");
+                done();
+            });
+        });
+        it('should not return IdP with diacritics when searching with non-matching diacritics', (done) => {
+            const q = "üniversité";
+            chai.request.execute(app)
+                .get(`/entities?q=${q}`)
+                .end((err,res) => {
+                    chai.expect(res.status).to.equal(200);
+                    let data = res.body;
+                    chai.expect(data.length).to.equal(0);
+                done();
+            });
+        });
         it('should return the SP for 3D Labs SP with a discovery_responses key', (done) => {
             const sp_id = _sha1_id("https://3d.labs.stonybrook.edu/shibboleth");
             chai.request.execute(app)


### PR DESCRIPTION
Add a diacritic-free version of the title when indexing, because the `en` locale from the metadata JSON file isn't always diacritic-free. This is to allow searching without having to use diacritics. For example, `Observatoire de la Côte d'Azur` will now appear when searching with `cote`.