### PR TITLE
Fixed ${BASE_URL} undefined error with /.well-known/webfinger

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const S_MAXAGE = parseInt(process.env.S_MAXAGE) || CACHE_TIME;
 const MAXAGE = parseInt(process.env.MAXAGE) || CACHE_TIME;
 const CONTENT_CACHE_HEADER = process.env.CONTENT_CACHE_HEADER || `s-maxage=${S_MAXAGE}, max-age=${MAXAGE}`;
 const META_CACHE_HEADER = process.env.META_CACHE_HEADER || "private, no-store";
+const BASE_URL = process.env.BASE_URL || "";
 
 const app = express();
 app.use(compression());


### PR DESCRIPTION
While trying to list available IdP ids using the /.well-known/webfinger URL I got the following error:

linux # curl https://ds.mydomain.de/.well-known/webfinger
```
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>ReferenceError: BASE_URL is not defined<br> &nbsp; &nbsp;at file:///usr/src/app/server.js:127:50<br> &nbsp; &nbsp;at Array.map (&lt;anonymous&gt;)<br> &nbsp; &nbsp;at file:///usr/src/app/server.js:126:51<br> &nbsp; &nbsp;at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)<br> &nbsp; &nbsp;at next (/usr/src/app/node_modules/express/lib/router/route.js:149:13)<br> &nbsp; &nbsp;at Route.dispatch (/usr/src/app/node_modules/express/lib/router/route.js:119:3)<br> &nbsp; &nbsp;at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)<br> &nbsp; &nbsp;at /usr/src/app/node_modules/express/lib/router/index.js:284:15<br> &nbsp; &nbsp;at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:346:12)<br> &nbsp; &nbsp;at next (/usr/src/app/node_modules/express/lib/router/index.js:280:10)</pre>
</body>
</html>
```

Seems like BASE_URL (defined in index.js) is not available for functions defined in server.js.
Getting BASE_URL from environment fixed that.

Side note to the developers:
Maybe the fallback should better be something like "http://localhost"?